### PR TITLE
override github channel dev->beta

### DIFF
--- a/api/github.go
+++ b/api/github.go
@@ -24,6 +24,9 @@ func (r GithubVersionResponse) Status() string {
 }
 
 func GetGoAlgorandReleaseWithResponse(http HttpPkgInterface, channel string) (*GithubVersionResponse, error) {
+	if channel == "dev" {
+		channel = "beta"
+	}
 	var versions GithubVersionResponse
 	resp, err := http.Get("https://api.github.com/repos/algorand/go-algorand/releases")
 	versions.HTTPResponse = resp
@@ -54,7 +57,6 @@ func GetGoAlgorandReleaseWithResponse(http HttpPkgInterface, channel string) (*G
 			versionResponse = &tn
 			break
 		}
-
 	}
 
 	// If the tag was not found, return an error

--- a/api/github.go
+++ b/api/github.go
@@ -24,9 +24,6 @@ func (r GithubVersionResponse) Status() string {
 }
 
 func GetGoAlgorandReleaseWithResponse(http HttpPkgInterface, channel string) (*GithubVersionResponse, error) {
-	if channel == "dev" {
-		channel = "beta"
-	}
 	var versions GithubVersionResponse
 	resp, err := http.Get("https://api.github.com/repos/algorand/go-algorand/releases")
 	versions.HTTPResponse = resp
@@ -57,6 +54,7 @@ func GetGoAlgorandReleaseWithResponse(http HttpPkgInterface, channel string) (*G
 			versionResponse = &tn
 			break
 		}
+
 	}
 
 	// If the tag was not found, return an error

--- a/internal/algod/status.go
+++ b/internal/algod/status.go
@@ -3,6 +3,7 @@ package algod
 import (
 	"context"
 	"errors"
+
 	"github.com/algorandfoundation/algorun-tui/api"
 )
 
@@ -138,18 +139,19 @@ func NewStatus(ctx context.Context, client api.ClientWithResponsesInterface, htt
 	}
 	status.Network = v.Network
 	status.Version = v.Version
+	status.NeedsUpdate = false
 
-	// TODO: last checked
-	releaseResponse, err := api.GetGoAlgorandReleaseWithResponse(httpPkg, v.Channel)
-	// Return the error and response
-	if err != nil {
-		return status, releaseResponse, err
-	}
-	// Update status update field
-	if releaseResponse != nil && status.Version != releaseResponse.JSON200 {
-		status.NeedsUpdate = true
-	} else {
-		status.NeedsUpdate = false
+	if v.Channel == "beta" || v.Channel == "stable" {
+		// TODO: last checked
+		releaseResponse, err := api.GetGoAlgorandReleaseWithResponse(httpPkg, v.Channel)
+		// Return the error and response
+		if err != nil {
+			return status, releaseResponse, err
+		}
+		// Update status update field
+		if releaseResponse != nil && status.Version != releaseResponse.JSON200 {
+			status.NeedsUpdate = true
+		}
 	}
 
 	return status.Get(ctx)


### PR DESCRIPTION
Fixes crash on fnet nodes because of `dev` release channel lookup on GH.

Would a better approach be to disable lookups entirely when a dev build is found?